### PR TITLE
chore: `NatSpec` documentation and `MerkleGen` Library

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,8 +4,8 @@ out = "out"
 libs = ["lib"]
 
 remappings = [
-    "ds-test/=lib/forge-std/lib/ds-test/src/",
     "forge-std/=lib/forge-std/src/",
+    "ds-test/=lib/forge-std/lib/ds-test/src/",
     "@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"
 ]
 

--- a/src/MerkleGen.sol
+++ b/src/MerkleGen.sol
@@ -31,7 +31,7 @@ library MerkleGen {
      * @notice Computes the next layer in the Merkle tree from the current layer.
      * @dev If the current layer has an odd number of nodes, the last node is duplicated.
      * @param layer Current layer of the Merkle tree.
-     * @return Computed parent layer.
+     * @return Computed next layer.
      */
     function compute_next_layer(bytes32[] memory layer) internal pure returns (bytes32[] memory) {
         if (layer.length == 1) {
@@ -43,13 +43,13 @@ library MerkleGen {
             layer = layer.append(layer[layer.length - 1]);
         }
 
-        bytes32[] memory parent_layer;
+        bytes32[] memory next_layer;
 
         for (uint256 i = 0; i < layer.length; i += 2) {
-            parent_layer = parent_layer.append(hash_internal_nodes(layer[i], layer[i + 1]));
+            next_layer = next_layer.append(hash_internal_nodes(layer[i], layer[i + 1]));
         }
 
-        return parent_layer;
+        return next_layer;
     }
 
     /**

--- a/src/MerkleGen.sol
+++ b/src/MerkleGen.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {ArrayLib} from "./libraries/ArrayLib.sol";
 
 /**
- * @dev Library for generating Merkle MultiProofs.
+ * @notice Library for generating Merkle MultiProofs.
  * @author sonicskye.
  */
 library MerkleGen {

--- a/src/MerkleGen.sol
+++ b/src/MerkleGen.sol
@@ -1,58 +1,89 @@
-/*
-A contract for Generating Merkle MultiProof.
-
-Contributors:
-- sonicskye
-
-*/
-
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.0;
 
-import {ArrayLib} from './libraries/ArrayLib.sol';
+import {ArrayLib} from "./libraries/ArrayLib.sol";
 
-contract MerkleGen {
-
+/**
+ * @dev Library for generating Merkle MultiProofs.
+ * @author sonicskye.
+ */
+library MerkleGen {
     using ArrayLib for *;
 
-    bool SOURCE_FROM_HASHES = true;
-    bool SOURCE_FROM_PROOF = false;
+    bool private constant SOURCE_FROM_HASHES = true;
+    bool private constant SOURCE_FROM_PROOF = false;
 
-    function hash_internal_node(bytes32 a, bytes32 b) internal pure returns (bytes32 h) {
+    /**
+     * @notice Hashes two internal nodes to generate their parent node.
+     * @param a First child node.
+     * @param b Second child node.
+     * @return h Hashed parent node.
+     */
+    function hash_internal_nodes(bytes32 a, bytes32 b) internal pure returns (bytes32 h) {
         if (a < b) {
             h = keccak256(abi.encodePacked(a, b));
-        }
-        else {
+        } else {
             h = keccak256(abi.encodePacked(b, a));
         }
     }
 
+    /**
+     * @notice Computes the next layer in the Merkle tree from the current layer.
+     * @dev If the current layer has an odd number of nodes, the last node is duplicated.
+     * @param layer Current layer of the Merkle tree.
+     * @return Computed parent layer.
+     */
     function compute_next_layer(bytes32[] memory layer) internal pure returns (bytes32[] memory) {
         if (layer.length == 1) {
             return layer;
-        } 
+        }
 
         if (layer.length % 2 == 1) {
             // Append with the same leaf if odd number of leaves
             layer = layer.append(layer[layer.length - 1]);
         }
 
-        bytes32[] memory next_layer;
+        bytes32[] memory parent_layer;
+
         for (uint256 i = 0; i < layer.length; i += 2) {
-            next_layer = next_layer.append(hash_internal_node(layer[i], layer[i + 1]));
+            parent_layer = parent_layer.append(hash_internal_nodes(layer[i], layer[i + 1]));
         }
-        return next_layer;
+
+        return parent_layer;
     }
 
+    /**
+     * @notice Calculates the parent index for a given node index.
+     * @param index Current node index.
+     * @return Parent node index.
+     */
     function parent_index(uint256 index) internal pure returns (uint256) {
         return index / 2;
     }
 
+    /**
+     * @notice Determines the sibling index of a given node index.
+     * @param index Current node index.
+     * @return Sibling node index.
+     */
     function sibling_index(uint256 index) internal pure returns (uint256) {
         return index ^ 1;
     }
 
-    function prove_single_layer(bytes32[] memory layer, uint256[] memory indices) internal view returns (uint256[] memory, bytes32[] memory, bool[] memory) {
+    /**
+     * @notice Generates the proof components for a single layer in the Merkle tree.
+     * @dev Processes selected indices to extract the necessary sibling hashes and flags.
+     * @param layer Current layer of the Merkle tree.
+     * @param indices Indices of the selected nodes in the current layer.
+     * @return Indices for the next layer.
+     * @return Sibling hashes required for the proof.
+     * @return Flags indicating the source of each proof hash.
+     */
+    function prove_single_layer(bytes32[] memory layer, uint256[] memory indices)
+        internal
+        pure
+        returns (uint256[] memory, bytes32[] memory, bool[] memory)
+    {
         uint256[] memory auth_indices;
         uint256[] memory next_indices;
         bool[] memory source_flags;
@@ -62,11 +93,10 @@ contract MerkleGen {
             uint256 x = indices[j];
             next_indices = next_indices.append(parent_index(x));
 
-            if ( ((j + 1) < indices.length) && (indices[j + 1] == sibling_index(x)) ) {
+            if (((j + 1) < indices.length) && (indices[j + 1] == sibling_index(x))) {
                 j += 1;
                 source_flags = source_flags.append(SOURCE_FROM_HASHES);
-            }
-            else {
+            } else {
                 auth_indices = auth_indices.append(sibling_index(x));
                 source_flags = source_flags.append(SOURCE_FROM_PROOF);
             }
@@ -77,7 +107,7 @@ contract MerkleGen {
         for (uint256 i = 0; i < auth_indices.length; i++) {
             // Here, if the index is out of bounds, we use the last element of the layer
             if (layer.length - 1 < auth_indices[i]) {
-                subProof[i] = layer[auth_indices[i]-1];
+                subProof[i] = layer[auth_indices[i] - 1];
             } else {
                 subProof[i] = layer[auth_indices[i]];
             }
@@ -86,6 +116,12 @@ contract MerkleGen {
         return (next_indices, subProof, source_flags);
     }
 
+    /**
+     * @notice Counts the number of occurrences of a specific flag in an array.
+     * @param flags Array of boolean flags.
+     * @param flag Flag to count.
+     * @return Number of times the flag appears in the array.
+     */
     function helper_count(bool[] memory flags, bool flag) internal pure returns (uint256) {
         uint256 count = 0;
         for (uint256 i = 0; i < flags.length; i++) {
@@ -96,10 +132,27 @@ contract MerkleGen {
         return count;
     }
 
-    function verify_compute_root(bytes32[] memory leaves, bytes32[] memory proof_hashes, bool[] memory proof_source_flags) internal view returns (bytes32) {
+    /**
+     * @notice Verifies and computes the Merkle root from the provided leaves and proof components.
+     * @dev Reconstructs the Merkle root by iteratively hashing pairs based on the source flags.
+     * @dev The total number of hashes must equal the number of source flags plus one.
+     * @dev The number of proof hashes must match the number of `SOURCE_FROM_PROOF` flags.
+     * @param leaves Selected leaves to be included in the proof.
+     * @param proof_hashes Sibling hashes extracted from the proof.
+     * @param proof_source_flags Flags indicating the source of each proof hash.
+     * @return Computed Merkle root.
+     */
+    function verify_compute_root(
+        bytes32[] memory leaves,
+        bytes32[] memory proof_hashes,
+        bool[] memory proof_source_flags
+    ) internal pure returns (bytes32) {
         uint256 total_hashes = leaves.length + proof_hashes.length - 1;
-        require(total_hashes == proof_source_flags.length, "Invalid total hashes");
-        require(helper_count(proof_source_flags, SOURCE_FROM_PROOF) == proof_hashes.length, "Invalid number of proof hashes");
+        require(total_hashes == proof_source_flags.length, "MerkleGen: Invalid total hashes.");
+        require(
+            helper_count(proof_source_flags, SOURCE_FROM_PROOF) == proof_hashes.length,
+            "MerkleGen: Invalid number of proof hashes."
+        );
 
         bytes32[] memory hashes = new bytes32[](total_hashes);
         // Fill hashes with leaves[0]
@@ -120,13 +173,11 @@ contract MerkleGen {
                 if (leaf_pos < leaves.length) {
                     a = leaves[leaf_pos];
                     leaf_pos += 1;
-                }
-                else {
+                } else {
                     a = hashes[hash_pos];
                     hash_pos += 1;
                 }
-            }
-            else if (proof_source_flags[i] == SOURCE_FROM_PROOF) {
+            } else if (proof_source_flags[i] == SOURCE_FROM_PROOF) {
                 a = proof_hashes[proof_pos];
                 proof_pos += 1;
             }
@@ -135,32 +186,43 @@ contract MerkleGen {
             if (leaf_pos < leaves.length) {
                 b = leaves[leaf_pos];
                 leaf_pos += 1;
-            }
-            else {
+            } else {
                 b = hashes[hash_pos];
                 hash_pos += 1;
             }
 
             // Compute hash
-            hashes[i] = hash_internal_node(a, b);
+            hashes[i] = hash_internal_nodes(a, b);
         }
 
         if (total_hashes > 0) {
             return hashes[total_hashes - 1];
-        }
-        else {
+        } else {
             return leaves[0];
         }
-
     }
 
-    function gen(bytes32[] memory hashed_leaves, uint256[] memory selected_indexes) public view returns (bytes32[] memory, bool[] memory, bytes32){
+    /**
+     * @notice Generates a Merkle MultiProof for the selected leaves.
+     * @dev Constructs the necessary proof components and verifies the Merkle root.
+     * @dev The computed root must match the actual root of the Merkle tree.
+     * @param hashed_leaves The array of hashed leaves in the Merkle tree.
+     * @param selected_indexes The indices of the leaves to include in the proof.
+     * @return Sibling hashes required for the proof.
+     * @return Flags indicating the source of each proof hash.
+     * @return Merkle root of the tree.
+     */
+    function gen(bytes32[] memory hashed_leaves, uint256[] memory selected_indexes)
+        public
+        pure
+        returns (bytes32[] memory, bool[] memory, bytes32)
+    {
         bytes32[] memory layer = hashed_leaves.copy();
-        // If odd number of leaves, append with the same leaf
+        // Append with the same leaf if odd number of leaves
         if (layer.length % 2 == 1) {
             layer = layer.append(layer[layer.length - 1]);
         }
-        // Create two dimensional array
+        // Create a two dimensional array
         bytes32[][] memory layers = new bytes32[][](1);
         layers[0] = layer;
         bytes32[] memory next_layer;
@@ -176,7 +238,8 @@ contract MerkleGen {
 
         bytes32[] memory subproof;
         bool[] memory source_flags;
-        for (uint256 i = 0; i < layers.length - 1; i++) { // Exclude the last layer because it is the root
+        for (uint256 i = 0; i < layers.length - 1; i++) {
+            // Exclude the last layer because it's the root
             layer = layers[i];
             (indices, subproof, source_flags) = prove_single_layer(layer, indices);
             proof_hashes = proof_hashes.extend(subproof);
@@ -192,7 +255,7 @@ contract MerkleGen {
         bytes32 root = verify_compute_root(indexed_leaves, proof_hashes, proof_source_flags);
 
         // Check if computed root is the same as the root of the tree
-        require(root == layers[layers.length-1][0], "Invalid root");
+        require(root == layers[layers.length - 1][0], "Invalid root");
 
         // Convert proof_source_flags to bits and uint256
         uint256 proof_flag_bits = 0;
@@ -201,16 +264,12 @@ contract MerkleGen {
             if (proof_source_flags[i] == SOURCE_FROM_HASHES) {
                 proof_flag_bits_bool[i] = true;
                 proof_flag_bits = proof_flag_bits | (1 << i);
-                
-            }
-            else {
+            } else {
                 proof_flag_bits_bool[i] = false;
                 proof_flag_bits = proof_flag_bits | (0 << i);
             }
         }
 
         return (proof_hashes, proof_flag_bits_bool, root);
-
     }
-
 }

--- a/src/Prover.sol
+++ b/src/Prover.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.0;
 import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 
 /**
- * @dev Wrapper library for proving Merkle MultiProofs.
+ * @notice Wrapper library for proving Merkle MultiProofs.
  * @author sonicskye.
  */
 library Prover {
     /**
-     * @notice Verifies the validity of a Merkle multiproof.
+     * @notice Verifies the validity of a Merkle MultiProof.
      * @dev Uses OpenZeppelin's `multiProofVerifyCalldata` to validate a multiproof.
      * @param proof The array of sibling hashes that help prove the inclusion of the leaves.
      * @param flag A boolean array that indicates whether each node is from the proof or hashes.

--- a/src/Prover.sol
+++ b/src/Prover.sol
@@ -1,20 +1,27 @@
-/*
-A contract for wrapping prover.
-
-Contributors:
-- sonicskye
-
-*/
-
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.0;
 
-import {MerkleProof} from '@openzeppelin/contracts/utils/cryptography/MerkleProof.sol';
+import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 
-contract Prover {
-
-    function prove(bytes32[] calldata proof, bool[] calldata proofFlags, bytes32 root, bytes32[] calldata leaves) public pure returns(bool) {
-
-        return MerkleProof.multiProofVerifyCalldata(proof, proofFlags, root, leaves);
+/**
+ * @dev Wrapper library for proving Merkle MultiProofs.
+ * @author sonicskye.
+ */
+library Prover {
+    /**
+     * @notice Verifies the validity of a Merkle multiproof.
+     * @dev Uses OpenZeppelin's `multiProofVerifyCalldata` to validate a multiproof.
+     * @param proof The array of sibling hashes that help prove the inclusion of the leaves.
+     * @param flag A boolean array that indicates whether each node is from the proof or hashes.
+     * @param root Root hash of the Merkle tree.
+     * @param leaves Leaf nodes that are being proved to be part of the Merkle tree.
+     * @return A boolean value indicating whether the proof is valid or not.
+     */
+    function prove(bytes32[] calldata proof, bool[] calldata flag, bytes32 root, bytes32[] calldata leaves)
+        public
+        pure
+        returns (bool)
+    {
+        return MerkleProof.multiProofVerifyCalldata(proof, flag, root, leaves);
     }
 }

--- a/src/libraries/ArrayLib.sol
+++ b/src/libraries/ArrayLib.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 /**
- * @dev Library for array operations.
+ * @notice Library for array operations.
  * @author sonicskye.
  */
 library ArrayLib {

--- a/src/libraries/ArrayLib.sol
+++ b/src/libraries/ArrayLib.sol
@@ -1,18 +1,17 @@
-/*
-A library for handling array operations needed by MerkleGen contract.
-
-Contributors:
-- sonicskye
-
-*/
-
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.0;
 
+/**
+ * @dev Library for array operations.
+ * @author sonicskye.
+ */
 library ArrayLib {
-
-    // Bytes32 array operations
-
+    /**
+     * @notice Appends a `bytes32` value to an existing `bytes32[]` array.
+     * @param arr The array to which the value will be appended.
+     * @param val The value to append to the array.
+     * @return A new array containing all elements of `arr` with `val` appended.
+     */
     function append(bytes32[] memory arr, bytes32 val) public pure returns (bytes32[] memory) {
         bytes32[] memory newArr = new bytes32[](arr.length + 1);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -22,6 +21,12 @@ library ArrayLib {
         return newArr;
     }
 
+    /**
+     * @notice Combines two arrays by concatenating them.
+     * @param arr The array to extend.
+     * @param vals The array of values to append to `arr`.
+     * @return A new array containing all elements of `arr` followed by all elements of `vals`.
+     */
     function extend(bytes32[] memory arr, bytes32[] memory vals) public pure returns (bytes32[] memory) {
         bytes32[] memory newArr = new bytes32[](arr.length + vals.length);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -33,8 +38,12 @@ library ArrayLib {
         return newArr;
     }
 
-    // Bytes32 two dimensional array operations
-
+    /**
+     * @notice Appends a `bytes32[]` array to a two-dimensional `bytes32[][]` array.
+     * @param arr The 2D array to which the value will be appended.
+     * @param val The array to append to the 2D array.
+     * @return A new 2D array containing all elements of `arr` with `val` appended.
+     */
     function append(bytes32[][] memory arr, bytes32[] memory val) public pure returns (bytes32[][] memory) {
         bytes32[][] memory newArr = new bytes32[][](arr.length + 1);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -44,7 +53,11 @@ library ArrayLib {
         return newArr;
     }
 
-    // Copy bytes32 array
+    /**
+     * @notice Copies a `bytes32[]` array into a new array.
+     * @param arr The array to copy.
+     * @return A new array containing the same elements as `arr`.
+     */
     function copy(bytes32[] memory arr) public pure returns (bytes32[] memory) {
         bytes32[] memory newArr = new bytes32[](arr.length);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -53,8 +66,12 @@ library ArrayLib {
         return newArr;
     }
 
-    // Uint256 array operations
-
+    /**
+     * @notice Appends a `uint256` value to an existing `uint256[]` array.
+     * @param arr The array to which the value will be appended.
+     * @param val The value to append to the array.
+     * @return A new array containing all elements of `arr` with `val` appended.
+     */
     function append(uint256[] memory arr, uint256 val) public pure returns (uint256[] memory) {
         uint256[] memory newArr = new uint256[](arr.length + 1);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -64,6 +81,12 @@ library ArrayLib {
         return newArr;
     }
 
+    /**
+     * @notice Extends a `uint256[]` array with another `uint256[]` array.
+     * @param arr The array to extend.
+     * @param vals The array of values to append to `arr`.
+     * @return A new array containing all elements of `arr` followed by all elements of `vals`.
+     */
     function extend(uint256[] memory arr, uint256[] memory vals) public pure returns (uint256[] memory) {
         uint256[] memory newArr = new uint256[](arr.length + vals.length);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -75,6 +98,11 @@ library ArrayLib {
         return newArr;
     }
 
+    /**
+     * @notice Copies a `uint256[]` array into a new array.
+     * @param arr The array to copy.
+     * @return A new array containing the same elements as `arr`.
+     */
     function copy(uint256[] memory arr) public pure returns (uint256[] memory) {
         uint256[] memory newArr = new uint256[](arr.length);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -83,8 +111,12 @@ library ArrayLib {
         return newArr;
     }
 
-    // Bool array operations
-
+    /**
+     * @notice Appends a `bool` value to an existing `bool[]` array.
+     * @param arr The array to which the value will be appended.
+     * @param val The value to append to the array.
+     * @return A new array containing all elements of `arr` with `val` appended.
+     */
     function append(bool[] memory arr, bool val) public pure returns (bool[] memory) {
         bool[] memory newArr = new bool[](arr.length + 1);
         for (uint256 i = 0; i < arr.length; i++) {
@@ -94,6 +126,12 @@ library ArrayLib {
         return newArr;
     }
 
+    /**
+     * @notice Extends a `bool[]` array with another `bool[]` array.
+     * @param arr The array to extend.
+     * @param vals The array of values to append to `arr`.
+     * @return A new array containing all elements of `arr` followed by all elements of `vals`.
+     */
     function extend(bool[] memory arr, bool[] memory vals) public pure returns (bool[] memory) {
         bool[] memory newArr = new bool[](arr.length + vals.length);
         for (uint256 i = 0; i < arr.length; i++) {

--- a/test/MerkleGen.t.sol
+++ b/test/MerkleGen.t.sol
@@ -1,29 +1,16 @@
-/*
-Testing for MerkleGen.sol.
-
-Contributors:
-- sonicskye
-
-*/
-
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.0;
 
 import {Test, console} from "forge-std/Test.sol";
 import {MerkleGen} from "../src/MerkleGen.sol";
 import {Prover} from "../src/Prover.sol";
 
+/**
+ * @dev Tests for MerkleGen.sol.
+ * @author sonicskye.
+ */
 contract MerkleGenTest is Test {
-
-    MerkleGen public merkleGen;
-    Prover public prover;
-
-    function setUp() public {
-        merkleGen = new MerkleGen();
-        prover = new Prover();
-    }
-
-    /// @notice A standard 4-leaf Merkle tree with all known values
+    /// @dev A test for standard 4-leaf Merkle tree with all known values.
     function test_prove() public {
         // Generate an array of bytes32 leaves
         bytes32[] memory leaves = new bytes32[](4);
@@ -45,17 +32,16 @@ contract MerkleGenTest is Test {
         }
 
         // Generate the proof
-        (bytes32[] memory proof, bool[] memory proofFlagBits, bytes32 root) = merkleGen.gen(leaves, indices);
+        (bytes32[] memory proof, bool[] memory proofFlagBits, bytes32 root) = MerkleGen.gen(leaves, indices);
 
         emit log_named_bytes32("root", root);
 
         // Verify the proof
-        assertTrue(prover.prove(proof, proofFlagBits, root, leaf_indexes));
-        
+        assertTrue(Prover.prove(proof, proofFlagBits, root, leaf_indexes));
     }
 
-    /// @notice A fuzz test for the Merkle tree
-    function testFuzz_prove(uint256 seed, bool[] memory select_leaves_, uint256 numLeaves) public view {
+    /// @dev A fuzz test for the Merkle tree.
+    function testFuzz_prove(uint256 seed, bool[] memory select_leaves_, uint256 numLeaves) public pure {
         //uint256 numLeaves = 5;
         // Assume
         numLeaves = bound(numLeaves, 1, 10000);
@@ -92,12 +78,9 @@ contract MerkleGenTest is Test {
         }
 
         // Generate the proof
-        (bytes32[] memory proof, bool[] memory proofFlagBits, bytes32 root) = merkleGen.gen(leaves, indices);
+        (bytes32[] memory proof, bool[] memory proofFlagBits, bytes32 root) = MerkleGen.gen(leaves, indices);
 
         // Verify the proof
-        assertTrue(prover.prove(proof, proofFlagBits, root, leaf_indexes));
+        assertTrue(Prover.prove(proof, proofFlagBits, root, leaf_indexes));
     }
-
-
-
 }


### PR DESCRIPTION
Closes #1 
Closes #2

- MerkleGen Library instead of Contract
- Used `forge fmt` for better formatting
- Added `NatSpec` Documentation
- Some changes of variable/function names for better code readability
- All of the tests are passing ✅ 